### PR TITLE
fix: report proper user agent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,7 @@ class Fetcher {
     const res = await (this.options.fetch || fetch)(url, {
       headers: {
         "user-agent":
-          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+          "Sitefetch (https://github.com/egoist/sitefetch)",
       },
     })
 


### PR DESCRIPTION
Report an actual user agent for this scraper to websites being scraped instead of masquerading.

If you're making a scraper that tries to concurrently fetch as many pages as possible without any delays and not checking robots.txt then at least be a decent netizen and identify yourself as the culprit.